### PR TITLE
Add campaign type argument to get_campaigns_by_account_id

### DIFF
--- a/lib/bing/ads/api/v12/services/campaign_management.rb
+++ b/lib/bing/ads/api/v12/services/campaign_management.rb
@@ -9,9 +9,9 @@ module Bing
               super(options)
             end
 
-            def get_campaigns_by_account_id(account_id=nil)
+            def get_campaigns_by_account_id(account_id=nil, campaign_type: "Search")
               account_id ||= @account_id
-              response = call(:get_campaigns_by_account_id, account_id: account_id)
+              response = call(:get_campaigns_by_account_id, account_id: account_id, campaign_type: campaign_type)
               response_body = response_body(response, __method__)
               [response_body[:campaigns][:campaign]].flatten.compact
             end

--- a/lib/bing/ads/version.rb
+++ b/lib/bing/ads/version.rb
@@ -1,5 +1,5 @@
 module Bing
   module Ads
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end


### PR DESCRIPTION
## What did we change?
Adds a kwarg for campaign_type, with default value "Search"

## Why did we change it?
Bing Ads supports multiple different [campaign types](https://docs.microsoft.com/en-us/bingads/campaign-management-service/campaigntype?view=bingads-12&viewFallbackFrom=bingads-11). The campaign_type argument [here](https://docs.microsoft.com/en-us/bingads/campaign-management-service/getcampaignsbyids?view=bingads-12&viewFallbackFrom=bingads-11) defaults to "Search" and we'd like to be able to control that.

## How did we test?
Set the local as a path for dependency and tested that the request gets the desired results.